### PR TITLE
correcting config for rss feed urls

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ google_analytics:
 
 # Your website URL (e.g. http://barryclark.github.io or http://www.barryclark.co)
 # Used for Sitemap.xml and your RSS feed
-url: https://obonaventure.github.io/cnp3blog/
+url: https://obonaventure.github.io
 
 # If you're hosting your site at a Project repository on GitHub pages
 # (http://yourusername.github.io/repository-name)


### PR DESCRIPTION
feed urls are misconfigured and points for example to https://obonaventure.github.io/cnp3blog//cnp3blog/apple/ instead of https://obonaventure.github.io/cnp3blog/apple/