### PR TITLE
Fix code blocks highlighting

### DIFF
--- a/_sass/_highlights.scss
+++ b/_sass/_highlights.scss
@@ -1,5 +1,5 @@
 
-.highlight {
+pre.highlight {
   background-color: #efefef;
   padding: 7px 7px 7px 10px;
   border: 1px solid #ddd;
@@ -7,7 +7,7 @@
   -webkit-box-shadow: 3px 3px rgba(0,0,0,0.1);
   box-shadow: 3px 3px rgba(0,0,0,0.1);
   margin: 20px 0 20px 0;
-  overflow: scroll;
+  overflow: auto;
 }
 
 code {


### PR DESCRIPTION
* Restrict 'highligh' to only apply to `<pre>` tags as the rouge highlighter 
seems to always nest highlight classes when formatting code blocks, 
i.e. causes `<div class="highlight"><pre class=highlight">##code` 
which causes nested scrollbars to appear.
* Switch scrollbar visibility to auto